### PR TITLE
:bulb: Implement automatic stream implementation selection

### DIFF
--- a/pystreamapi/__stream_converter.py
+++ b/pystreamapi/__stream_converter.py
@@ -29,6 +29,7 @@ class StreamConverter:
         elif isinstance(stream, SequentialStream):
             stream.__class__ = ParallelStream
             stream._init_parallelizer()
+        stream._set_implementation_explicit()
         return stream
 
     @staticmethod
@@ -38,4 +39,14 @@ class StreamConverter:
             stream.__class__ = SequentialNumericStream
         elif isinstance(stream, ParallelStream):
             stream.__class__ = SequentialStream
+        stream._set_implementation_explicit()
+        return stream
+
+    @staticmethod
+    def choose_implementation(stream: BaseStream) -> BaseStream:
+        """Chooses the implementation of the stream based on whether
+        parallelization is recommended or not."""
+        if not stream._implementation_explicit:
+            if stream._is_parallelism_recommended():
+                return StreamConverter.to_parallel_stream(stream)
         return stream

--- a/pystreamapi/_lazy/process.py
+++ b/pystreamapi/_lazy/process.py
@@ -20,3 +20,7 @@ class Process:
             self.__work(self.__arg)
         else:
             self.__work()
+
+    def has_name(self, name):
+        """Check if process is method of name"""
+        return self.__work.__name__ == name.__name__

--- a/pystreamapi/_streams/__sequential_stream.py
+++ b/pystreamapi/_streams/__sequential_stream.py
@@ -4,6 +4,7 @@ from typing import Callable, Any
 import pystreamapi._streams.__base_stream as stream
 from pystreamapi.__optional import Optional
 from pystreamapi._itertools.tools import reduce, flat_map, peek
+from pystreamapi._streams.__base_stream import terminal
 from pystreamapi._streams.error.__error import _sentinel
 
 _identity_missing = object()
@@ -12,14 +13,14 @@ _identity_missing = object()
 class SequentialStream(stream.BaseStream):
     """The sequential implementation of BaseStream"""
 
-    @stream.terminal
+    @terminal
     def all_match(self, predicate: Callable[[Any], bool]):
         return all(self._itr(self._source, mapper=predicate))
 
     def _filter(self, predicate: Callable[[Any], bool]):
         self._source = self._itr(self._source, condition=predicate)
 
-    @stream.terminal
+    @terminal
     def find_any(self):
         try:
             return Optional.of(next(iter(self._source)))
@@ -39,7 +40,7 @@ class SequentialStream(stream.BaseStream):
             groups[key].append(element)
         return groups
 
-    @stream.terminal
+    @terminal
     def for_each(self, action: Callable):
         for item in self._source:
             self._one(mapper=action, item=item)
@@ -50,7 +51,7 @@ class SequentialStream(stream.BaseStream):
     def _peek(self, action: Callable):
         self._source = peek(self._source, lambda x: self._one(mapper=action, item=x))
 
-    @stream.terminal
+    @terminal
     def reduce(self, predicate: Callable, identity=_identity_missing, depends_on_state=False):
         if len(self._source) > 0:
             if identity is not _identity_missing:
@@ -58,6 +59,6 @@ class SequentialStream(stream.BaseStream):
             return Optional.of(reduce(predicate, self._source, handler=self))
         return identity if identity is not _identity_missing else Optional.empty()
 
-    @stream.terminal
+    @terminal
     def to_dict(self, key_mapper: Callable[[Any], Any]) -> dict:
         return self._group_to_dict(key_mapper)

--- a/tests/_streams/test_base_stream.py
+++ b/tests/_streams/test_base_stream.py
@@ -1,8 +1,8 @@
+# pylint: disable=protected-access
 import itertools
 import unittest
 
 from pystreamapi.__optional import Optional
-
 from pystreamapi.__stream import Stream
 from pystreamapi._streams.__parallel_stream import ParallelStream
 from pystreamapi._streams.__sequential_stream import SequentialStream
@@ -118,6 +118,18 @@ class TestBaseStream(unittest.TestCase):
     def test_of_noneable_valid(self):
         result = Stream.of_noneable([1, 2, 3]).to_list()
         self.assertListEqual(result, [1, 2, 3])
+
+    def test_parallelization_recommended(self):
+        stream = Stream.of(range(4000)).filter(lambda x: x % 2 == 0)
+        self.assertTrue(stream._is_parallelism_recommended())
+
+    def test_parallelization_not_recommended(self):
+        stream = Stream.of(range(10)).filter(lambda x: x % 2 == 0)
+        self.assertFalse(stream._is_parallelism_recommended())
+
+    def test_parallelization_not_recommended_no_filter(self):
+        stream = Stream.of(range(4000)).map(lambda x: x % 2 == 0)
+        self.assertFalse(stream._is_parallelism_recommended())
 
     def test_sort_unsorted(self):
         result = Stream.of([3, 2, 9, 1]).sorted().to_list()


### PR DESCRIPTION
This pull request introduces enhancements to the `pystreamapi` library, focusing on stream implementation flexibility, parallelization recommendations, and improved testing coverage. The key changes include adding functionality for automatic stream implementation selection, refining parallelism recommendations, and ensuring robust handling of generators.

### Stream Implementation Enhancements:
* Added `choose_implementation` method to `StreamConverter` for automatic selection between sequential and parallel stream implementations based on parallelism recommendations. (`pystreamapi/__stream_converter.py`)
* Introduced `_is_parallelism_recommended` and `_set_implementation_explicit` methods in `BaseStream` to determine and control stream implementation switching. (`pystreamapi/_streams/__base_stream.py`)

### Parallelization Logic:
* Updated `terminal` decorator to integrate automatic implementation selection during stream operations. (`pystreamapi/_streams/__base_stream.py`)
* Added tests to validate parallelization recommendation logic under different scenarios. (`tests/_streams/test_base_stream.py`)

### Generator Handling:
* Improved handling of infinite and finite generators, ensuring compatibility with sequential streams and adding tests for edge cases. (`tests/_streams/test_stream_implementation.py`) [[1]](diffhunk://#diff-688a5bf3dbd28ecf824ff50bcaaf82f94a353626c0a8a16551d45f0abc1774c6L85-R95) [[2]](diffhunk://#diff-688a5bf3dbd28ecf824ff50bcaaf82f94a353626c0a8a16551d45f0abc1774c6L206-R223)

### Testing Enhancements:
* Expanded test coverage for the `choose_implementation` method, including integration tests with stream operations and numeric streams. (`tests/_streams/test_stream_converter.py`)
* Added pylint directives to test files for cleaner code analysis. (`tests/_streams/test_base_stream.py`, `tests/_streams/test_stream_converter.py`) [[1]](diffhunk://#diff-1cc414090e9d77e13e3306161fe493ad7b86e20f0b69f0723b771562fa6c21eaR1-L5) [[2]](diffhunk://#diff-718af30d714db5a90fdd68b7060b76c775f54e9a373b14f615c85280d6be717aR1-R6)