### PR TITLE
:technologist: Make iterator error handler optional and pin poetry-publish

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,6 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build and publish to pypi
-        uses: JRubics/poetry-publish@v2.1
+        uses: JRubics/poetry-publish@4b3306307f536bbfcb559603629b3b4f6aef5ab8
         with:
           pypi_token: ${{ secrets.PYPI_API_TOKEN }}

--- a/pystreamapi/_itertools/tools.py
+++ b/pystreamapi/_itertools/tools.py
@@ -1,10 +1,10 @@
 # pylint: disable=protected-access
-from typing import Iterable
+from typing import Iterable, Optional
 
 from pystreamapi._streams.error.__error import ErrorHandler, _sentinel
 
 
-def dropwhile(predicate, iterable, handler: ErrorHandler = None):
+def dropwhile(predicate, iterable, handler: Optional[ErrorHandler] = None):
     """
     Drop items from the iterable while predicate(item) is true.
     Afterward, return every element until the iterable is exhausted.
@@ -24,7 +24,7 @@ def dropwhile(predicate, iterable, handler: ErrorHandler = None):
 _initial_missing = object()
 
 
-def reduce(function, sequence, initial=_initial_missing, handler: ErrorHandler = None):
+def reduce(function, sequence, initial=_initial_missing, handler: Optional[ErrorHandler] = None):
     """
     Apply a function of two arguments cumulatively to the items of a sequence
     or iterable, from left to right, to reduce the iterable to a single


### PR DESCRIPTION
## Summary by Sourcery

Clarify error handler typing in iterator utilities and pin the poetry publish GitHub Action to a specific commit for publishing.

Enhancements:
- Annotate iterator utility error handler parameters as Optional to better reflect nullable usage.

CI:
- Pin the JRubics/poetry-publish GitHub Action in the Python publish workflow to a specific commit SHA for more deterministic releases.